### PR TITLE
Refact: 주소 검색 시 잦은 api호출로 인한 과부하 개선

### DIFF
--- a/src/page/AddressPage.tsx
+++ b/src/page/AddressPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Header from "../components/Header";
 import addressStyle from "../css/page/addressPage.module.css";
 import { CiSearch } from "react-icons/ci";
@@ -6,6 +6,17 @@ import { CiLocationArrow1 } from "react-icons/ci";
 import Modal from "../components/Modal";
 import { IoIosArrowBack } from "react-icons/io";
 import { useNavigate, useSearchParams } from "react-router-dom";
+
+function useDebounce<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debounced;
+}
 
 export default function AddressPage() {
   const [searchParams] = useSearchParams();
@@ -19,6 +30,18 @@ export default function AddressPage() {
   const navigate = useNavigate();
   const [address, setAddress] = useState<string>("");
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const debouncedValue = useDebounce(inputValue, 500);
+
+  useEffect(() => {
+    if (debouncedValue) {
+      handleAddress(debouncedValue);
+    } else {
+      setResults([]);
+    }
+  }, [debouncedValue]);
+
+
+
 
   const handleAddress = async (query: string) => {
     if (!query) return;
@@ -145,7 +168,7 @@ export default function AddressPage() {
             placeholder="주소 또는 장소를 입력해주세요"
             onChange={(e) => {
               setInputValue(e.target.value);
-              handleAddress(e.target.value);
+              // handleAddress(e.target.value);
             }}
             onFocus={() => setShowLocation(true)}
           />


### PR DESCRIPTION
## #️⃣연관된 이슈

- #28 

## 📝작업 내용

이번 리팩토링 이전에는 주소를 `input`에 작성할 때 `onChange`마다 `kakao api`를 호출하여 리스트를 보여줬었습니다.
이로 인해 잦은 api호출이 일어났고, 트래픽이 많은 서비스에서는 서버 과부하 가능성이 생길 수 있습니다.

- '다이소'만 쳤는데 수많은 api호출이 있음을 볼 수 있습니다.
<img width="1919" height="835" alt="image" src="https://github.com/user-attachments/assets/bb0e1797-b422-40a1-b637-72ffab3e95ca" />
<img width="223" height="155" alt="image" src="https://github.com/user-attachments/assets/15dce154-d595-42c0-9ca5-886ea4508979" />

<br> 

이와 같은 문제를 개선하기 위해 `Debounce`를 적용했습니다.
`onChange`될 때마다 `kakao api`를 호출하는게 아니라 사용자가 입력을 마치고 일정 시간이 지나면 호출할 수 있도록 설정했습니다. 저는 0.5초의 **delay**를 줬습니다.

## 이전 코드
```typescript
        <input
            type="text"
            value={inputValue}
            className={addressStyle.addressInput}
            placeholder="주소 또는 장소를 입력해주세요"
            onChange={(e) => {
              setInputValue(e.target.value);
              handleAddress(e.target.value);
            }}
            onFocus={() => setShowLocation(true)}
        />
```

<br>

## 이후 코드

### useDebounce 훅 
```typescript
function useDebounce<T>(value: T, delay: number) {
  const [debounced, setDebounced] = useState(value);

  useEffect(() => {
    const handler = setTimeout(() => setDebounced(value), delay);
    return () => clearTimeout(handler);
  }, [value, delay]);

  return debounced;
}
```

### 훅 사용
```typescript
  const debouncedValue = useDebounce(inputValue, 500);

  useEffect(() => {
    if (debouncedValue) {
      handleAddress(debouncedValue);
    } else {
      setResults([]);
    }
  }, [debouncedValue]);
```

### input 
```typescript
        <input
            type="text"
            value={inputValue}
            className={addressStyle.addressInput}
            placeholder="주소 또는 장소를 입력해주세요"
            onChange={(e) => {
              setInputValue(e.target.value);
              // handleAddress(e.target.value);
            }}
            onFocus={() => setShowLocation(true)}
        />
```


## 비교

- '다이소' 검색 시 delay를 줘서 api호출이 줄어든 걸 볼 수 있습니다.
<img width="1919" height="835" alt="image" src="https://github.com/user-attachments/assets/f4210287-1026-40a7-84a6-ecb0007396e2" />
<img width="249" height="172" alt="image" src="https://github.com/user-attachments/assets/e651fd8e-72a6-4d90-9f95-199613bb5f65" />

<br> 

- INP 개선

| debounce 적용 전 | debounce 적용 후 |
|-----------------|-----------------|
| <img width="270" height="167" alt="image" src="https://github.com/user-attachments/assets/3ddac182-29b2-4442-91e8-fe333ca9cf15" /> | <img width="271" height="177" alt="image" src="https://github.com/user-attachments/assets/0dd35e66-12f4-46da-93c6-922200dc2cde" /> |


## ❌ 이슈 닫기

- close #28 
